### PR TITLE
Add support for multiple application names

### DIFF
--- a/lib/new_relic/agent.ex
+++ b/lib/new_relic/agent.ex
@@ -122,7 +122,10 @@ defmodule NewRelic.Agent do
   end
 
   defp app_name() do
-    String.split(Application.get_env(:new_relic, :application_name), ";")
+    case Application.get_env(:new_relic, :application_name) do
+      nil -> [nil]
+      app -> String.split(app, ";")
+    end
   end
 
   defp license_key() do

--- a/lib/new_relic/agent.ex
+++ b/lib/new_relic/agent.ex
@@ -44,7 +44,7 @@ defmodule NewRelic.Agent do
         language: "elixir",
         pid: l2i(:os.getpid()),
         host: l2b(hostname),
-        app_name: [app_name()],
+        app_name: app_name(),
         labels: [],
         utilization: NewRelic.Utils.utilization(),
         environment: NewRelic.Utils.elixir_environment(),
@@ -122,7 +122,7 @@ defmodule NewRelic.Agent do
   end
 
   defp app_name() do
-    Application.get_env(:new_relic, :application_name)
+    String.split(Application.get_env(:new_relic, :application_name), ";")
   end
 
   defp license_key() do

--- a/lib/new_relic/agent.ex
+++ b/lib/new_relic/agent.ex
@@ -121,7 +121,7 @@ defmodule NewRelic.Agent do
     :erlang.list_to_integer(char_list)
   end
 
-  defp app_name() do
+  def app_name() do
     case Application.get_env(:new_relic, :application_name) do
       nil -> [nil]
       app -> String.split(app, ";")

--- a/test/new_relic/agent_test.exs
+++ b/test/new_relic/agent_test.exs
@@ -1,0 +1,28 @@
+defmodule NewRelic.AgentTest do
+  use ExUnit.Case, async: false
+  alias NewRelic.Agent
+
+  setup do
+    assert Application.get_env(:new_relic, :application_name) == "Test"
+
+    on_exit(fn ->
+      Application.put_env(:new_relic, :application_name, "Test")
+    end)
+  end
+
+  describe "app_name/0" do
+    test "returns a list with a string if not separated" do
+      assert Agent.app_name() == ["Test"]
+    end
+
+    test "returns a list with a nil if env var is nil" do
+      Application.put_env(:new_relic, :application_name, nil)
+      assert Agent.app_name() == [nil]
+    end
+
+    test "returns a list with multiple values if semi-colon separated" do
+      Application.put_env(:new_relic, :application_name, "app-name-1;app-name-2")
+      assert Agent.app_name() == ["app-name-1", "app-name-2"]
+    end
+  end
+end


### PR DESCRIPTION
We would like be able to use more than one application name for monitoring both within region and as a cohesive app. This will allow us to so submit semi-colon separated application names